### PR TITLE
Disable requireHostHeader option for httpServer

### DIFF
--- a/lib/ArduinoDevice.js
+++ b/lib/ArduinoDevice.js
@@ -10,6 +10,7 @@
 const events = require('events');
 const rp = require('request-promise-native');
 const express = require('express');
+const http = require('http');
 const bodyParser = require('body-parser');
 const promiseRetry = require('promise-retry');
 
@@ -34,16 +35,17 @@ class ArduinoDevice extends events.EventEmitter {
 			rc: null
 		}, opts);
 
-		this._webserver = express();
+		this._app = express();
+        this._webserver = http.createServer({ requireHostHeader: false }, this._app);
 
-		this._webserver.use(bodyParser.json());
+		this._app.use(bodyParser.json());
 
-		this._webserver.get('/', (req, res) => {
+		this._app.get('/', (req, res) => {
 			this._debug('Webserver: index requested');
 			res.send('');
 		});
 
-		this._webserver.post('/emit/*', (req, res) => {
+		this._app.post('/emit/*', (req, res) => {
 			try {
 				let urlParts = req.url.split('/');
 				let emType = urlParts[2];
@@ -64,12 +66,12 @@ class ArduinoDevice extends events.EventEmitter {
 			}
 		});
 
-		this._webserver.get('*', (req, res) => {
+		this._app.get('*', (req, res) => {
 			this._debug('Ignored unhandled GET request: '+req.url);
 			res.send('Unknown (GET)', 404);
 		});
 
-		this._webserver.post('*', (req, res) => {
+		this._app.post('*', (req, res) => {
 			this._debug('Ignored unhandled POST request: '+req.url);
 			res.send('Unknown (POST)', 404);
 		});


### PR DESCRIPTION
#### Issue Description
Running the app with node 22 results in triggers not working. 
#### Reproduction Scenario
- ESP32 with Homeyduino code that triggers a Flow with string argument every 10 seconds. 
- Running Homey app with remote Flag so the ESP can be discovered.
- Created a Flow with the `All triggers` trigger card leading to a notification card that logs the trigger name.
##### Research
Homeyduino logs show requests are sent successfully. Looking at the Homey logs, no requests are received.
After updating the Homeyduino library to include response logging, it becomes clear the requests failed with a 400 (Bad Request) status.

``` HTTP
HTTP/1.1 400 Bad Request
Connection: close
Date: Fri, 24 Oct 2025 10:49:58 GMT
Transfer-Encoding: chunked

0
```
Setting up a simple express server that logs incoming requests and then returns status 200 confirms this behaviour. Sending a curl request with the default host header `curl http://localhost:1234` and without the host header `curl -H 'host:' http://localhost:1234` yields different results depending on the node version. When using node 18, both requests are logged by the server and complete successfully. Running this same scenario when using node 22 results in the latter (without host header) failing with status code 400, and not getting logged by the server.

This is also confirmed by the following issue: https://github.com/nodejs/node/issues/39033

Adding the `Host` header to the Homeyduino library fixes this issue, though this solution is not desired as this requires flashing all devices with firmware using the new library. A better alternative would be to allow requests regardless of whether they include a `Host` header.

The above issue also mentions the ability to disable this requirement, by passing `requireHostHeader: false` to the http server. By manually starting the http server instead of relying on express to do this, we can provide this option and disable the host header requirement.